### PR TITLE
Feat.명함 기능 구현하기

### DIFF
--- a/src/main/java/com/example/cardcase/card/CardController.java
+++ b/src/main/java/com/example/cardcase/card/CardController.java
@@ -1,0 +1,65 @@
+package com.example.cardcase.card;
+
+import com.example.cardcase.card.dto.CardDetailResponse;
+import com.example.cardcase.card.dto.CardSummaryResponse;
+import com.example.cardcase.common.apiPayload.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cards")
+public class CardController {
+    private final CardService cardService;
+
+    /**
+     * 공유 받은 명함 목록 조회
+     */
+    @GetMapping
+    public ApiResponse<List<CardSummaryResponse>> getMyCardList(
+            // TODO: @AuthenticationPrincipal 로 로그인 사용자 정보 가져오기
+            @RequestParam Long memberId // 임시 파라미터
+    ) {
+        List<CardSummaryResponse> cardList = cardService.getCardList(memberId);
+        return ApiResponse.success(cardList);
+    }
+
+    /**
+     * 공유 받은 명함 상세 조회 API
+     */
+    @GetMapping("/{cardId}")
+    public ApiResponse<CardDetailResponse> getCardDetail(@PathVariable Long cardId) {
+        CardDetailResponse cardDetail = cardService.getCardDetail(cardId);
+        return ApiResponse.success(cardDetail);
+    }
+
+    /**
+     * 공유받은 명함 삭제 API
+     */
+    @DeleteMapping("/{cardId}/my-case")
+    public ApiResponse<?> removeCardFromMyCase(
+            @PathVariable Long cardId,
+            // TODO: @AuthenticationPrincipal 로 로그인 사용자 정보 가져오기
+            @RequestParam Long memberId // 임시 파라미터
+    ) {
+        cardService.removeCardFromMyCase(memberId, cardId);
+        return ApiResponse.success();
+    }
+
+    /**
+     * 내 명함 삭제 API
+     */
+    @DeleteMapping("/{cardId}")
+    public ApiResponse<?> deleteBusinessCard(
+            @PathVariable Long cardId,
+            // TODO: @AuthenticationPrincipal 로 로그인 사용자 정보 가져오기
+            @RequestParam Long memberId // 임시 파라미터
+    ) throws AccessDeniedException {
+        // TODO: 삭제하더라도 공유받은 사람은 정보를 볼 수 있어야 한다??
+        cardService.deleteBusinessCard(memberId, cardId);
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/example/cardcase/card/CardService.java
+++ b/src/main/java/com/example/cardcase/card/CardService.java
@@ -1,0 +1,93 @@
+package com.example.cardcase.card;
+
+import com.example.cardcase.card.dto.CardDetailResponse;
+import com.example.cardcase.card.dto.CardSummaryResponse;
+import com.example.cardcase.card.entity.BusinessCard;
+import com.example.cardcase.card.entity.Relation;
+import com.example.cardcase.card.repository.BusinessCardRepository;
+import com.example.cardcase.card.repository.RelationRepository;
+import com.example.cardcase.common.apiPayload.error.CoreException;
+import com.example.cardcase.common.apiPayload.error.GlobalErrorType;
+import com.example.cardcase.oauth.domain.entity.Member;
+import com.example.cardcase.oauth.repository.MemberRepository; // Member 조회를 위해 필요
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CardService {
+
+    private final BusinessCardRepository businessCardRepository;
+    private final RelationRepository relationRepository;
+    //TODO : memberService를 이용해서 조회하는 것 고려. 어디에 의존할것인가
+    private final MemberRepository memberRepository;
+
+    /**
+     * 공유받은 명함 상세 조회
+     */
+    public List<CardSummaryResponse> getCardList(Long memberId) {
+        Member member = findMemberById(memberId);
+        List<Relation> relations = relationRepository.findByMember(member);
+
+        return relations.stream()
+                .map(relation -> CardSummaryResponse.from(relation.getBusinessCard()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 명함 상세 조회
+     */
+    public CardDetailResponse getCardDetail(Long cardId) {
+        BusinessCard businessCard = findBusinessCardById(cardId);
+        return CardDetailResponse.from(businessCard);
+    }
+
+    /**
+     * 공유받은 명함 삭제 (Relation 삭제)
+     */
+    @Transactional
+    public void removeCardFromMyCase(Long memberId, Long cardId) {
+        Member member = findMemberById(memberId);
+        Relation relation = relationRepository.findByMemberAndBusinessCardId(member, cardId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 명함을 명함첩에서 찾을 수 없습니다."));
+
+        relationRepository.delete(relation);
+    }
+
+    /**
+     * 명함 원본 삭제 (BusinessCard 삭제)
+     * TODO: 이 명함을 받은 모든 사람의 명함첩에서도 사라지게 됨.
+     *       권한 검증 코드 넣기. (자신이 만든 명함만 삭제 가능하도록)
+     *       삭제하기 보다는 user와의 연결을 끊는 방식으로 개선시키기
+     */
+    @Transactional
+    public void deleteBusinessCard(Long memberId, Long cardId) throws AccessDeniedException {
+        BusinessCard businessCard = findBusinessCardById(cardId);
+
+        if(businessCard.getMember() == null){
+            throw new CoreException(GlobalErrorType.E500);
+        }
+
+        businessCard.disown();
+        //트랜잭션이 있으므로 리포지토리 저장은 자동으로 발생!
+    }
+
+    // --- 2번 이상 중복되는 코드 빼기 ---
+    // TODO: 짧은 코드인데 함수로 빼는게 나은걸까?
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CoreException(GlobalErrorType.MEMBER_NOT_FOUND));
+    }
+
+    private BusinessCard findBusinessCardById(Long cardId) {
+        return businessCardRepository.findById(cardId)
+                .orElseThrow(() -> new EntityNotFoundException("명함을 찾을 수 없습니다. ID: " + cardId));
+    }
+}

--- a/src/main/java/com/example/cardcase/card/dto/CardDetailResponse.java
+++ b/src/main/java/com/example/cardcase/card/dto/CardDetailResponse.java
@@ -1,0 +1,35 @@
+package com.example.cardcase.card.dto;
+
+import com.example.cardcase.card.entity.BusinessCard;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CardDetailResponse {
+    private Long cardId;
+    private String name;
+    private String companyName;
+    private String department;
+    private String phoneNumber;
+    private String email;
+    private String companyEmail;
+    private String companyLocation;
+    private String sns;
+    private String companyNumber;
+
+    public static CardDetailResponse from(BusinessCard businessCard) {
+        return CardDetailResponse.builder()
+                .cardId(businessCard.getId())
+                .name(businessCard.getName())
+                .companyName(businessCard.getCompany_name())
+                .department(businessCard.getDepartment())
+                .phoneNumber(businessCard.getPhone_number())
+                .email(businessCard.getEmail())
+                .companyEmail(businessCard.getCompany_email())
+                .companyLocation(businessCard.getCompany_location())
+                .sns(businessCard.getSns())
+                .companyNumber(businessCard.getCompany_number())
+                .build();
+    }
+}

--- a/src/main/java/com/example/cardcase/card/dto/CardSummaryResponse.java
+++ b/src/main/java/com/example/cardcase/card/dto/CardSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.example.cardcase.card.dto;
+
+import com.example.cardcase.card.entity.BusinessCard;
+import lombok.Builder;
+import lombok.Getter;
+
+// 목록 조회 시 보여줄 최소한의 정보
+@Getter
+@Builder
+public class CardSummaryResponse {
+    private Long cardId;
+    private String name;
+    private String companyName;
+    private String department;
+
+    public static CardSummaryResponse from(BusinessCard businessCard) {
+        return CardSummaryResponse.builder()
+                .cardId(businessCard.getId())
+                .name(businessCard.getName())
+                .companyName(businessCard.getCompany_name())
+                .department(businessCard.getDepartment())
+                .build();
+    }
+}

--- a/src/main/java/com/example/cardcase/card/entity/BusinessCard.java
+++ b/src/main/java/com/example/cardcase/card/entity/BusinessCard.java
@@ -1,19 +1,26 @@
 package com.example.cardcase.card.entity;
 
+import com.example.cardcase.oauth.domain.entity.Member;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 public class BusinessCard {
 
     @Id
     @GeneratedValue
     private Long id;
 
+    @Column(nullable = false)
     private String name;
+
+    @Column(nullable = false)
     private String company_name;
+
     private String department;
     private String phone_number;
     private String email;
@@ -22,7 +29,15 @@ public class BusinessCard {
     private String sns;
     private String company_number;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")  // 유저에게 명함을 받은 것
+    private Member member;
 
-    @OneToMany(mappedBy = "businessCard" , cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "businessCard", cascade = CascadeType.ALL)
     private List<Relation> relations = new ArrayList<>();
+
+    //사용자가 자신의 명함을 삭제 시키더라도 공유받은 명함의 정보가 유지되도록 연결만 끊는다.
+    public void disown() {
+        this.member = null;
+    }
 }

--- a/src/main/java/com/example/cardcase/card/entity/Relation.java
+++ b/src/main/java/com/example/cardcase/card/entity/Relation.java
@@ -2,14 +2,15 @@ package com.example.cardcase.card.entity;
 
 import com.example.cardcase.oauth.domain.entity.Member;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Relation {
 
     @Id
     @GeneratedValue
     private Long id;
-
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")  // 유저에게 명함을 받은 것

--- a/src/main/java/com/example/cardcase/card/repository/BusinessCardRepository.java
+++ b/src/main/java/com/example/cardcase/card/repository/BusinessCardRepository.java
@@ -1,4 +1,7 @@
 package com.example.cardcase.card.repository;
 
-public class BusinessCardRepository {
+import com.example.cardcase.card.entity.BusinessCard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BusinessCardRepository extends JpaRepository<BusinessCard, Long> {
 }

--- a/src/main/java/com/example/cardcase/card/repository/RelationRepository.java
+++ b/src/main/java/com/example/cardcase/card/repository/RelationRepository.java
@@ -1,4 +1,16 @@
 package com.example.cardcase.card.repository;
 
-public class RelationRepository {
+import com.example.cardcase.card.entity.Relation;
+import com.example.cardcase.oauth.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import javax.swing.text.html.Option;
+import java.util.List;
+import java.util.Optional;
+
+public interface RelationRepository extends JpaRepository<Relation, Long> {
+    List<Relation> findByMember(Member member);
+
+    Optional<Relation> findByMemberAndBusinessCardId(Member member, Long businessCardId);
+
 }

--- a/src/main/java/com/example/cardcase/oauth/domain/entity/Member.java
+++ b/src/main/java/com/example/cardcase/oauth/domain/entity/Member.java
@@ -1,5 +1,6 @@
 package com.example.cardcase.oauth.domain.entity;
 
+import com.example.cardcase.card.entity.BusinessCard;
 import com.example.cardcase.card.entity.Relation;
 import com.example.cardcase.oauth.domain.Role;
 import jakarta.persistence.*;
@@ -7,9 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.data.repository.cdi.Eager;
 
-import javax.smartcardio.Card;
 import java.util.ArrayList;
 import java.util.List;
 @Builder
@@ -28,6 +27,10 @@ public class Member {
     private String name;
     @OneToMany(mappedBy = "member" , cascade = CascadeType.ALL)
     private List<Relation> relations = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member" , cascade = CascadeType.ALL)
+    private List<BusinessCard> businessCards = new ArrayList<>();
+
 
     @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
# 구현기능
- 공유 받은 명함 목록 조회
- 공유 받은 명함 상세 조회
- 공유 받은 명함 삭제
- 내 명함 삭제

# 변경사항(전달사항)
- BusinessCard Entity에도 user_id가 들어가도록 member랑 연관관계 추가해주었습니다.
- 회원가입/로그인 기능이 아직 안들어와서 현재 임시로 memberId파라미터를 받고 있습니다. (JWT도입 이후 AuthenticationPrincipal 사용 예정입니다. 기능 merge이후 테스트하면 comment 남기겠습니다.)
- 내 명함 삭제시 공유받은 사람들의 명함첩에서 해당 명함을 삭제시켜야 할지 의논이 필요합니다. (남기는게 맞는 것 같은데 개인정보 측면에서 문제가 될지 논의하면 좋을 것 같습니다. 현재는 남기는 로직으로 BusinessCard에 disown함수를 두어 연결을 끊도록 구현했습니다.)
- Dto는 현재 class로 구현했는데 시간 되는대로 record 타입으로 수정하겠습니다.
- 가능한 ApiResponse, CoreException을 사용했으나 errorType은 추가로 만들지 않은 상태입니다. 개선사항이 보이면 말씀해주세요.